### PR TITLE
[BUG] Fix wrong generated media queries

### DIFF
--- a/src/lib/merge-text-styles.ts
+++ b/src/lib/merge-text-styles.ts
@@ -31,7 +31,7 @@ class MediaCollection {
               ...current.data,
             };
           }
-          const mediaKey = '@media (min-width: ' + this.screens[current.media] + ')';
+          const mediaKey = '@media (min-width: ' + this.screens[current.media] + 'px)';
 
           return {
             ...collection,
@@ -91,14 +91,14 @@ const findMediaTypeFromClassName = (className: string, screens: Screens[]) => {
  *    fontSize: ...,
  *    fontWeight: ...,
  *    ...,
- *    '@media (min-width: 600): {
+ *    '@media (min-width: 600px): {
  *      fontSize: ...,
  *      ...,
  *    },
- *    '@media (min-width: 900): {
+ *    '@media (min-width: 900px): {
  *      ...,
  *    },
- *    '@media (min-width: 1200): {
+ *    '@media (min-width: 1200px): {
  *      ...,
  *    },
  *  }

--- a/src/utils/generate-styles/__snapshots__/generate-styles.test.js.snap
+++ b/src/utils/generate-styles/__snapshots__/generate-styles.test.js.snap
@@ -115,19 +115,19 @@ exports[`generateStyles merge text styles creates file with merged text styles a
       fontWeight: 600,
       textTransform: "initial",
       lineHeight: 1.12,
-      '@media (min-width: 600)': {
+      '@media (min-width: 600px)': {
       fontFamily: fontFamily.font1,
       fontSize: 38,
       fontWeight: 600,
       textTransform: "initial",
       lineHeight: 0.94,
-    },'@media (min-width: 900)': {
+    },'@media (min-width: 900px)': {
       fontFamily: fontFamily.font1,
       fontSize: 42,
       fontWeight: 600,
       textTransform: "initial",
       lineHeight: 0.85,
-    },'@media (min-width: 1200)': {
+    },'@media (min-width: 1200px)': {
       fontFamily: fontFamily.font1,
       fontSize: 46,
       fontWeight: 600,


### PR DESCRIPTION
Hello. 

The last release has a mistake in the generation of media queries.
It generates media queries without `px`.
And, as result, the generated file with test styles has typography like that:
```
'.v-500': {
    fontFamily: fontFamily.font3,
    fontSize: 28,
    fontWeight: 500,
    textTransform: 'uppercase',
    lineHeight: 1.4,
    '@media (min-width: 600)': {
      fontFamily: fontFamily.font3,
      fontSize: 32,
      fontWeight: 500,
      textTransform: 'uppercase',
      lineHeight: 1.4,
    },
    '@media (min-width: 900)': {
      fontFamily: fontFamily.font3,
      fontSize: 40,
      fontWeight: 500,
      textTransform: 'uppercase',
      lineHeight: 1.4,
    },
    '@media (min-width: 1280)': {
      fontFamily: fontFamily.font3,
      fontSize: 48,
      fontWeight: 500,
      textTransform: 'uppercase',
      lineHeight: 1.4,
    },
  },
```
All media queries must look like this:
```
  '@media (min-width: 600px)': {
...
    },
    '@media (min-width: 900px)': {
...
    },
    '@media (min-width: 1280px)': {
...
    },
```

This PR fixes it.