### PR TITLE
Add missing `blur` value for box-shadow css property

### DIFF
--- a/src/lib/get-effect-styles/index.ts
+++ b/src/lib/get-effect-styles/index.ts
@@ -22,6 +22,16 @@ export type EffectStyle = {
   [x: string]: GroupedEffectProperty;
 };
 
+const getComplexValue = <T>({
+  value,
+  postfix = '',
+  fallback = '',
+}: {
+  value: T;
+  postfix?: string;
+  fallback?: string;
+}) => (value !== undefined ? value + postfix : fallback);
+
 function groupEffectProperties(properties: Variable[]) {
   const grouped: { [key: string]: GroupedEffectProperty } = {};
 
@@ -77,9 +87,10 @@ export const getEffectStyles = (modes: Mode[], config: Config) => {
         if (value.type === 'shadow') {
           return {
             ...acc,
-            [keyName?.(`${item.name}/${key}`)]: `${value.x}px ${value.y}px ${
-              value.spread
-            }px ${formattedColor(value.color)}`,
+            [keyName?.(`${item.name}/${key}`)]: `${value.x}px ${value.y}px ${getComplexValue({
+              value: value.blur,
+              postfix: 'px',
+            })} ${value.spread}px ${formattedColor(value.color)}`,
           };
         }
         if (value.type === 'backdrop-blur' || value.type === 'blur') {

--- a/src/plugins/__snapshots__/effects-theme-plugin.test.ts.snap
+++ b/src/plugins/__snapshots__/effects-theme-plugin.test.ts.snap
@@ -25,12 +25,12 @@ exports[`effectsThemePlugin create theme data with one theme which doesn't exist
 --sh-blur-100: 8px;
 --sh-blur-200: 20px;
 --sh-blur-300: 32px;
---sh-shadow-100: 0px 1px 0px rgba(0, 0, 0, 0.05);
---sh-shadow-200: 0px 1px 0px rgba(0, 0, 0, 0.15);
---sh-shadow-300: 0px 4px -1px rgba(0, 0, 0, 0.15);
---sh-shadow-400: 0px 16px 0px rgba(0, 0, 0, 0.05);
---sh-shadow-500: 0px 16px -8px rgba(0, 0, 0, 0.10);
---sh-shadow-600: 0px 40px -8px rgba(0, 0, 0, 0.10);
+--sh-shadow-100: 0px 1px 4px 0px rgba(0, 0, 0, 0.05);
+--sh-shadow-200: 0px 1px 4px 0px rgba(0, 0, 0, 0.15);
+--sh-shadow-300: 0px 4px 4px -1px rgba(0, 0, 0, 0.15);
+--sh-shadow-400: 0px 16px 32px 0px rgba(0, 0, 0, 0.05);
+--sh-shadow-500: 0px 16px 16px -8px rgba(0, 0, 0, 0.10);
+--sh-shadow-600: 0px 40px 104px -8px rgba(0, 0, 0, 0.10);
 }"
 `;
 
@@ -99,7 +99,7 @@ exports[`effectsThemePlugin create theme data with one theme which doesn't exist
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     module.exports = {
-    boxShadow: {"100":"0px 1px 0px rgba(0, 0, 0, 0.05)","200":"0px 1px 0px rgba(0, 0, 0, 0.15)","300":"0px 4px -1px rgba(0, 0, 0, 0.15)","400":"0px 16px 0px rgba(0, 0, 0, 0.05)","500":"0px 16px -8px rgba(0, 0, 0, 0.10)","600":"0px 40px -8px rgba(0, 0, 0, 0.10)"},
+    boxShadow: {"100":"0px 1px 4px 0px rgba(0, 0, 0, 0.05)","200":"0px 1px 4px 0px rgba(0, 0, 0, 0.15)","300":"0px 4px 4px -1px rgba(0, 0, 0, 0.15)","400":"0px 16px 32px 0px rgba(0, 0, 0, 0.05)","500":"0px 16px 16px -8px rgba(0, 0, 0, 0.10)","600":"0px 40px 104px -8px rgba(0, 0, 0, 0.10)"},
     backdropBlur: {"100":"8px","200":"20px"},
     blur: {"100":"8px","200":"20px","300":"32px"},
     }
@@ -157,12 +157,12 @@ exports[`effectsThemePlugin should create css files with css variables: /export-
 --sh-blur-100: 8px;
 --sh-blur-200: 20px;
 --sh-blur-300: 32px;
---sh-shadow-100: 0px 0px 1px rgba(255, 255, 255, 0.10);
---sh-shadow-200: 0px 0px 1px rgba(255, 255, 255, 0.10);
---sh-shadow-300: 0px 0px 1px rgba(255, 255, 255, 0.10);
---sh-shadow-400: 0px 0px 1px rgba(255, 255, 255, 0.20);
---sh-shadow-500: 0px 0px 1px rgba(255, 255, 255, 0.20);
---sh-shadow-600: 0px 0px 1px rgba(255, 255, 255, 0.20);
+--sh-shadow-100: 0px 0px 0px 1px rgba(255, 255, 255, 0.10);
+--sh-shadow-200: 0px 0px 0px 1px rgba(255, 255, 255, 0.10);
+--sh-shadow-300: 0px 0px 0px 1px rgba(255, 255, 255, 0.10);
+--sh-shadow-400: 0px 0px 0px 1px rgba(255, 255, 255, 0.20);
+--sh-shadow-500: 0px 0px 0px 1px rgba(255, 255, 255, 0.20);
+--sh-shadow-600: 0px 0px 0px 1px rgba(255, 255, 255, 0.20);
 }"
 `;
 
@@ -174,12 +174,12 @@ exports[`effectsThemePlugin should create css files with css variables: /export-
 --sh-blur-100: 8px;
 --sh-blur-200: 20px;
 --sh-blur-300: 32px;
---sh-shadow-100: 0px 1px 0px rgba(0, 0, 0, 0.05);
---sh-shadow-200: 0px 1px 0px rgba(0, 0, 0, 0.15);
---sh-shadow-300: 0px 4px -1px rgba(0, 0, 0, 0.15);
---sh-shadow-400: 0px 16px 0px rgba(0, 0, 0, 0.05);
---sh-shadow-500: 0px 16px -8px rgba(0, 0, 0, 0.10);
---sh-shadow-600: 0px 40px -8px rgba(0, 0, 0, 0.10);
+--sh-shadow-100: 0px 1px 4px 0px rgba(0, 0, 0, 0.05);
+--sh-shadow-200: 0px 1px 4px 0px rgba(0, 0, 0, 0.15);
+--sh-shadow-300: 0px 4px 4px -1px rgba(0, 0, 0, 0.15);
+--sh-shadow-400: 0px 16px 32px 0px rgba(0, 0, 0, 0.05);
+--sh-shadow-500: 0px 16px 16px -8px rgba(0, 0, 0, 0.10);
+--sh-shadow-600: 0px 40px 104px -8px rgba(0, 0, 0, 0.10);
 }"
 `;
 
@@ -222,7 +222,7 @@ exports[`effectsThemePlugin should create js files with css variables: /export-p
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     module.exports = {
-    boxShadow: {"100":"0px 0px 1px rgba(255, 255, 255, 0.10)","200":"0px 0px 1px rgba(255, 255, 255, 0.10)","300":"0px 0px 1px rgba(255, 255, 255, 0.10)","400":"0px 0px 1px rgba(255, 255, 255, 0.20)","500":"0px 0px 1px rgba(255, 255, 255, 0.20)","600":"0px 0px 1px rgba(255, 255, 255, 0.20)"},
+    boxShadow: {"100":"0px 0px 0px 1px rgba(255, 255, 255, 0.10)","200":"0px 0px 0px 1px rgba(255, 255, 255, 0.10)","300":"0px 0px 0px 1px rgba(255, 255, 255, 0.10)","400":"0px 0px 0px 1px rgba(255, 255, 255, 0.20)","500":"0px 0px 0px 1px rgba(255, 255, 255, 0.20)","600":"0px 0px 0px 1px rgba(255, 255, 255, 0.20)"},
     backdropBlur: {"100":"8px","200":"20px"},
     blur: {"100":"8px","200":"20px","300":"32px"},
     }
@@ -248,7 +248,7 @@ exports[`effectsThemePlugin should create js files with css variables: /export-p
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     module.exports = {
-    boxShadow: {"100":"0px 1px 0px rgba(0, 0, 0, 0.05)","200":"0px 1px 0px rgba(0, 0, 0, 0.15)","300":"0px 4px -1px rgba(0, 0, 0, 0.15)","400":"0px 16px 0px rgba(0, 0, 0, 0.05)","500":"0px 16px -8px rgba(0, 0, 0, 0.10)","600":"0px 40px -8px rgba(0, 0, 0, 0.10)"},
+    boxShadow: {"100":"0px 1px 4px 0px rgba(0, 0, 0, 0.05)","200":"0px 1px 4px 0px rgba(0, 0, 0, 0.15)","300":"0px 4px 4px -1px rgba(0, 0, 0, 0.15)","400":"0px 16px 32px 0px rgba(0, 0, 0, 0.05)","500":"0px 16px 16px -8px rgba(0, 0, 0, 0.10)","600":"0px 40px 104px -8px rgba(0, 0, 0, 0.10)"},
     backdropBlur: {"100":"8px","200":"20px"},
     blur: {"100":"8px","200":"20px","300":"32px"},
     }


### PR DESCRIPTION
The blur property for box-shadow is not added into CSS and TX variable, although this property exists inside the tree of `effects` block.