### PR TITLE
Add `weights` comments for fonts

### DIFF
--- a/src/lib/text/get-font-family.test.ts
+++ b/src/lib/text/get-font-family.test.ts
@@ -1,0 +1,107 @@
+import { getFontFamily } from './get-font-family';
+
+describe('getFontFamily', () => {
+  it('should return correct formatted fonts with and without extra fields', () => {
+    expect(
+      getFontFamily([
+        {
+          variables: [
+            {
+              name: 'title/900/font',
+              type: 'STRING',
+              scopes: ['FONT_FAMILY'],
+              value: 'Inter',
+            },
+            {
+              name: 'title/900/size',
+              type: 'FLOAT',
+              scopes: ['FONT_SIZE'],
+              value: 24,
+            },
+            {
+              name: 'title/900/line',
+              type: 'FLOAT',
+              scopes: ['LINE_HEIGHT'],
+              value: 32,
+            },
+            {
+              name: 'title/900/weight',
+              type: 'FLOAT',
+              scopes: ['FONT_WEIGHT'],
+              value: 600,
+            },
+          ],
+        },
+        {
+          variables: [
+            {
+              name: 'title/800/font',
+              type: 'STRING',
+              scopes: ['FONT_FAMILY'],
+              value: 'Inter',
+            },
+            {
+              name: 'title/800/size',
+              type: 'FLOAT',
+              scopes: ['FONT_SIZE'],
+              value: 16,
+            },
+            {
+              name: 'title/800/line',
+              type: 'FLOAT',
+              scopes: ['LINE_HEIGHT'],
+              value: 24,
+            },
+            {
+              name: 'title/800/weight',
+              type: 'FLOAT',
+              scopes: ['FONT_WEIGHT'],
+              value: 500,
+            },
+          ],
+        },
+        {
+          variables: [
+            {
+              name: 'title/700/font',
+              type: 'STRING',
+              scopes: ['FONT_FAMILY'],
+              value: 'Roboto',
+            },
+            {
+              name: 'title/700/size',
+              type: 'FLOAT',
+              scopes: ['FONT_SIZE'],
+              value: 14,
+            },
+            {
+              name: 'title/700/line',
+              type: 'FLOAT',
+              scopes: ['LINE_HEIGHT'],
+              value: 24,
+            },
+            {
+              name: 'title/700/weight',
+              type: 'FLOAT',
+              scopes: ['FONT_WEIGHT'],
+              value: 400,
+            },
+          ],
+        },
+      ]),
+    ).toEqual({
+      fontFamily: { font1: 'Inter', font2: 'Roboto' },
+      formattedFontFamilyWithAdditionalFonts: {
+        font1: { title: "'Inter', Arial, sans-serif", comment: 'used weights: 500, 600' },
+        font2: { title: "'Roboto', Arial, sans-serif", comment: 'used weights: 400' },
+      },
+    });
+  });
+
+  it('should return empty created fonts objects', () => {
+    expect(getFontFamily([])).toEqual({
+      fontFamily: {},
+      formattedFontFamilyWithAdditionalFonts: {},
+    });
+  });
+});

--- a/src/lib/text/get-font-family.ts
+++ b/src/lib/text/get-font-family.ts
@@ -1,29 +1,75 @@
-import { Mode, Variable } from '@/types';
+import { type FloatVariable, Mode, type StringVariable, Variable } from '@/types';
 
-import { uniqueElementsBy } from './unique-elements-by';
+const variableHasWeight = (variable: Variable): variable is FloatVariable =>
+  variable.scopes.includes('FONT_WEIGHT');
+
+const variableHasFontFamily = (variable: Variable): variable is StringVariable =>
+  variable.scopes.includes('FONT_FAMILY');
 
 export const getFontFamily = (modes: Mode[]) => {
-  const variables = modes.reduce<Variable[]>((acc, item) => [...acc, ...item.variables], []);
-  const uniqFamily = uniqueElementsBy<Variable>(variables, (a, b) => {
-    if (a.scopes.includes('FONT_FAMILY') && b.scopes.includes('FONT_FAMILY')) {
-      return a.value == b.value;
-    }
+  const variables = modes
+    .reduce<Variable[]>((acc, item) => [...acc, ...item.variables], [])
+    .reduce<Record<string, { font: string; weight: number }>>((collection, item) => {
+      if (variableHasFontFamily(item)) {
+        const name = item.name.replace(/\/font$/, '');
+        const modifiedItem = !collection[name]
+          ? { font: item.value, weight: 0 }
+          : { ...collection[name], font: item.value };
 
-    return true;
-  });
+        return { ...collection, [name]: modifiedItem };
+      }
 
-  const formattedFontFamilyWithAdditionalFonts = uniqFamily.reduce(
-    (acc, item, i) => ({
-      ...acc,
-      [`font${i + 1}`]: `'${item.value}', Arial, sans-serif`,
-    }),
+      if (variableHasWeight(item)) {
+        const name = item.name.replace(/\/weight$/, '');
+        const modifiedItem = !collection[name]
+          ? { font: '', weight: item.value }
+          : { ...collection[name], weight: item.value };
+
+        return { ...collection, [name]: modifiedItem };
+      }
+
+      return collection;
+    }, {});
+
+  const fontAndWeightList = Object.keys(variables).reduce<Record<string, number[]>>(
+    (collection, variableTitle) => {
+      const item = variables[variableTitle];
+      if (item.font && item.weight) {
+        const weights: number[] = collection[item.font] ? [...collection[item.font]] : [];
+        // If such weight has not been added yet
+        if (!weights.includes(item.weight)) {
+          weights.push(item.weight);
+        }
+
+        return {
+          ...collection,
+          [item.font]: weights,
+        };
+      }
+
+      return collection;
+    },
     {},
   );
 
-  const formattedFontFamily = uniqFamily.reduce(
-    (acc, item, i) => ({
+  const formattedFontFamilyWithAdditionalFonts = Object.keys(fontAndWeightList).reduce<
+    Record<string, { title: string; comment: string }>
+  >((acc, fontName, i) => {
+    const weights = fontAndWeightList[fontName] || [];
+
+    return {
       ...acc,
-      [`font${i + 1}`]: item.value,
+      [`font${i + 1}`]: {
+        title: `'${fontName}', Arial, sans-serif`,
+        comment: weights.length > 0 ? `used weights: ${weights.sort().join(', ')}` : '',
+      },
+    };
+  }, {});
+
+  const formattedFontFamily = Object.keys(fontAndWeightList).reduce<Record<string, string>>(
+    (acc, fontName, i) => ({
+      ...acc,
+      [`font${i + 1}`]: fontName,
     }),
     {},
   );

--- a/src/plugins/__snapshots__/text-styles-plugin.test.ts.snap
+++ b/src/plugins/__snapshots__/text-styles-plugin.test.ts.snap
@@ -5,7 +5,10 @@ exports[`textStylesPlugin should create data with custom keyName function 1`] = 
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     
-      const fontFamily = {"font1":"'Inter', Arial, sans-serif"};
+      const fontFamily = {
+        font1: "'Inter', Arial, sans-serif", // used weights: 400, 500, 600
+
+      };
 
       const textVariants = {'body-500/bs__extra': {
       
@@ -594,7 +597,10 @@ exports[`textStylesPlugin should create data with merged styles 1`] = `
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     
-      const fontFamily = {"font1":"'Inter', Arial, sans-serif"};
+      const fontFamily = {
+        font1: "'Inter', Arial, sans-serif", // used weights: 400, 500, 600
+
+      };
 
       const textVariants = {'body-500-bs': {
       
@@ -1183,7 +1189,10 @@ exports[`textStylesPlugin should create data with merged styles when the screens
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     
-      const fontFamily = {"font1":"'Inter', Arial, sans-serif"};
+      const fontFamily = {
+        font1: "'Inter', Arial, sans-serif", // used weights: 400, 500, 600
+
+      };
 
       const textVariants = {'body-500-bs': {
       
@@ -1772,7 +1781,10 @@ exports[`textStylesPlugin should create data with merged styles when the screens
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     
-      const fontFamily = {"font1":"'Inter', Arial, sans-serif"};
+      const fontFamily = {
+        font1: "'Inter', Arial, sans-serif", // used weights: 400, 500, 600
+
+      };
 
       const textVariants = {'body-500-bs': {
       
@@ -2361,7 +2373,10 @@ exports[`textStylesPlugin should write generated date for default config 1`] = `
     /* eslint-disable max-lines */
     /* eslint-disable @typescript-eslint/naming-convention */
     
-      const fontFamily = {"font1":"'Inter', Arial, sans-serif"};
+      const fontFamily = {
+        font1: "'Inter', Arial, sans-serif", // used weights: 400, 500, 600
+
+      };
 
       const textVariants = {'body-500-bs': {
       

--- a/src/plugins/text-styles-plugin.ts
+++ b/src/plugins/text-styles-plugin.ts
@@ -29,7 +29,7 @@ export const textStylesPlugin: Plugin = (
 
     if (result.fontFamily) {
       for (const [fontTitle, fontValue] of Object.entries(result.fontFamily)) {
-        log('[info:text-styles/fonts] >>> ', `'${fontTitle}' => '${fontValue}'`);
+        log('[info:text-styles/fonts] >>> ', `'${fontTitle}' => '${fontValue.title}'`);
       }
     }
 
@@ -43,12 +43,13 @@ export const textStylesPlugin: Plugin = (
 
     const textStyles = sortTextStyles(rawTextStyle);
 
-    const fontFamilyTemplate = JSON.stringify(result.fontFamily);
     const textStylesTemplate = `{${textStyles.join()}};`;
     writeFile(
       addEslintDisableRules(
         `
-      const fontFamily = ${fontFamilyTemplate};
+      const fontFamily = {
+        ${Object.entries(result.fontFamily).map(([key, { title, comment }]) => `${key}: "${title}", ${!!comment ? '// ' + comment : ''}\n`)}
+      };
 
       const textVariants = ${textStylesTemplate};
 


### PR DESCRIPTION
The convenient comments with all used weights for each font have been added in this PR.

So instead of that
```js
 const fontFamily = {
   font1: "'Inter', Arial, sans-serif",
};
```
the extractor will generate such fonts: 
```js
 const fontFamily = {
   font1: "'Inter', Arial, sans-serif",  // used weights: 400, 500, 600
};
```